### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   build-backend:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -19,6 +21,8 @@ jobs:
       - run: npm test
 
   build-frontend:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
Potential fix for [https://github.com/glowedjellys/glowed/security/code-scanning/9](https://github.com/glowedjellys/glowed/security/code-scanning/9)

To fix this issue, an explicit `permissions` block should be added to both the `build-backend` and `build-frontend` jobs in `.github/workflows/npm-publish-github-packages.yml`. These blocks should specify the minimum necessary GitHub token permissions required for checkout and tests, which is typically just `contents: read`. The block should be positioned directly under each job heading and above `runs-on` to follow standard conventions. No changes to other jobs are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
