### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: Node.js CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/glowedjellys/glowed/security/code-scanning/11](https://github.com/glowedjellys/glowed/security/code-scanning/11)

To fix the issue, explicitly restrict permissions for the workflow job by adding a `permissions` block. The minimal recommended setting for most CI workflows is `contents: read`, which allows read-only access to repository contents and disables all write operations. This block should be added at the job (`build`) level—or, for single-job workflows like this, it may be clearer and more future-proof to add it at the workflow root (lines 5-6). This ensures that unless explicitly overridden, all jobs (including `build`) will run with reduced, least-privilege permissions.  
Specifically:
- Add a `permissions:` block with at least `contents: read` after the `name:` or before the `on:` block at the top of the file.
- No additional imports, definitions, or method changes are needed—since this is a YAML workflow file, only the permissions YAML block is required.
- Do **not** add any unnecessary permissions: start with just the minimal `contents: read`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
