### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   build-backend:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: ./backend
@@ -23,6 +25,8 @@ jobs:
 
   build-frontend:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: ./frontend


### PR DESCRIPTION
Potential fix for [https://github.com/glowedjellys/glowed/security/code-scanning/10](https://github.com/glowedjellys/glowed/security/code-scanning/10)

To fix the problem, add an explicit `permissions` block with the minimum required permissions to the jobs that currently lack it (`build-backend` and `build-frontend`). Since these jobs only need to check out code and run tests, they do not require any special permissions beyond `contents: read`, which allows for read-only access to repository contents. This role can be added directly to the affected jobs. The changes are:
- For the `build-backend` job (line 11 onward), insert a `permissions:` block with `contents: read` after `runs-on: ubuntu-latest`.
- For the `build-frontend` job (line 25 onward), do the same.

No new methods, imports, or variable definitions are required—this is a configuration change within the YAML workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
