### PR TITLE
Potential fix for code scanning alert no. 16: Server-side request forgery

### DIFF
--- a/frontend/src/pages/Register.js
+++ b/frontend/src/pages/Register.js
@@ -2,7 +2,24 @@ import React, { useState } from "react";
 import axios from "axios";
 import { useNavigate, Link } from "react-router-dom";
 
-const API_URL = process.env.REACT_APP_API_URL;
+// Securely allowlist permitted API endpoints to prevent SSRF
+const ALLOWED_API_URLS = [
+  "https://api.example.com",
+  "https://dev-api.example.com",
+  "http://localhost:4000"
+];
+
+function getSafeApiUrl(envUrl) {
+  // Ensure URL matches an allowed base domain
+  if (ALLOWED_API_URLS.includes(envUrl)) {
+    return envUrl;
+  }
+  // Optionally: throw error or use default safe value
+  // throw new Error("Invalid API URL configuration");
+  return ALLOWED_API_URLS[0];
+}
+
+const API_URL = getSafeApiUrl(process.env.REACT_APP_API_URL);
 
 export default function Register() {
   const [username, setUsername] = useState("");


### PR DESCRIPTION
Potential fix for [https://github.com/glowedjellys/glowed/security/code-scanning/16](https://github.com/glowedjellys/glowed/security/code-scanning/16)

To prevent SSRF risk, do not use environment variables for hostnames directly in API requests unless they are validated. Instead, restrict `API_URL` to a set of allowed values (an allowlist), enforced in the code. This can be done by checking if `API_URL` matches one of a small set of hardcoded, known-good domain prefixes before using it to construct the axios request URL. If it doesn't, refuse to proceed and throw an error, or fallback to a default safe value.

The fix should be applied in the region where `API_URL` is assigned and where it is used for the request.  
We'll add a function to validate the API URL prefix.  
No new external dependencies are needed; standard JavaScript will suffice.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
